### PR TITLE
CSV export completed when '-e' flag is passed. (resolves #1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "mocha": "^2.4.5"
   },
   "dependencies": {
-    "cli-table": "^0.3.1"
+    "cli-table": "^0.3.1",
+    "json2csv": "^3.7.0",
+    "minimist": "^1.2.0"
   }
 }


### PR DESCRIPTION
e.g.

```
trendy-cucumber ./test/feature-test-results.json -e
```

Generates `high_level_metrics.csv`, `feature_metrics.csv`.

**Note** that the blank header column is replaced with an underscore (_) since `json2csv` renders the entire column blank if any header fields are blank.

Resolves https://github.com/blad/trendy-cucumber/issues/1.
