### PR TITLE
Add node version

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ Trendy Cucumber accepts json input. You can generate json output specify the `--
 cucumberjs --format json:./test/feature-test-results.json
 ```
 
+## Requirements
+Require node `4.0.0` or higher
+
 ## License (MIT)
 
 ```

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "bin": {
     "trendy-cucumber": "index.js"
   },
+  "engines": {
+    "node": ">= 4.0.0"
+  },
   "scripts": {
     "test": "mocha ./tests"
   },


### PR DESCRIPTION
Hi

I added the node version to both readme and package.json as asked in issue #7. This is the oldest version (4.0.0) that supports arrows functions out of the box
